### PR TITLE
bug fixes - don't skip generating notes, compare the correct tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,7 @@ jobs:
       - uses: chainguard-dev/actions/goimports@main
 
       - name: Login to registry
+        if: github.repository_owner == 'helm'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: quay.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,7 +58,7 @@ snapshot:
 dockers:
   - goos: linux
     goarch: amd64
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ if ne .GitURL \"https://github.com/helm/chart-releaser\" }}true{{ else }}false{{ end }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
@@ -77,7 +77,7 @@ dockers:
 
   - goos: linux
     goarch: arm64
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ if ne .GitURL \"https://github.com/helm/chart-releaser\" }}true{{ else }}false{{ end }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
@@ -97,7 +97,7 @@ dockers:
   - goos: linux
     goarch: arm
     goarm: 7
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ if ne .GitURL \"https://github.com/helm/chart-releaser\" }}true{{ else }}false{{ end }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
@@ -116,7 +116,7 @@ dockers:
 
   - goos: linux
     goarch: s390x
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ if ne .GitURL \"https://github.com/helm/chart-releaser\" }}true{{ else }}false{{ end }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:
@@ -135,7 +135,7 @@ dockers:
 
   - goos: linux
     goarch: ppc64le
-    skip_push: "{{ ne .GitURL 'https://github.com/helm/chart-releaser' | toYaml }}"
+    skip_push: "{{ if ne .GitURL \"https://github.com/helm/chart-releaser\" }}true{{ else }}false{{ end }}"
     dockerfile: Dockerfile
     use: buildx
     image_templates:

--- a/magefile.go
+++ b/magefile.go
@@ -137,5 +137,12 @@ func Release() error {
 		return err
 	}
 
-	return sh.RunV("goreleaser", "release", "--clean")
+	var args []string
+	args = append(args, "release", "--clean")
+
+	if os.Getenv("GITHUB_REPOSITORY_OWNER") != "helm" {
+		args = append(args, "--skip=docker,homebrew")
+	}
+
+	return sh.RunV("goreleaser", args...)
 }

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -249,7 +249,8 @@ func (r *Releaser) getReleaseNotes(chart *chart.Chart) (string, error) {
 			}
 		}
 		fmt.Printf("The release note file %q, is not present in the chart package\n", r.config.ReleaseNotesFile)
-	} else if r.config.GenerateReleaseNotes {
+	}
+	if r.config.GenerateReleaseNotes {
 		latestRelease, err := r.github.GetLatestChartRelease(context.TODO(), chart.Metadata.Name)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to get latest release for chart %s", chart.Metadata.Name)


### PR DESCRIPTION
The `else if` skipped generating release notes if `cr upload --release-notes-file` was passed and the file did not exist.